### PR TITLE
Feature gridline arguments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,10 @@ Imports:
     stringr,
     tidyr,
     dichromat,
-    purrr
+    purrr,
+    downloader,
+    zip,
+    sf
 URL: https://statistikzh.github.io/statR/
 BugReports: https://github.com/statistikZH/statR/issues
 Suggests: 

--- a/R/theme_stat.r
+++ b/R/theme_stat.r
@@ -8,7 +8,8 @@
 #' @param axis.label.pos position of x and y-axis labels, can be set to "top", "center", or "bottom".
 #' @param axis.lines presence of axis lines, can be set to "x", "y", or "both".
 #' @param ticks presence of axis ticks, can be set to "x", "y", or "both".
-#' @param minor.grid.lines presence of minor grid lines on the y-axis, can be set to TRUE or FALSE.
+#' @param major.grid.lines presence of major grid lines, can be set to "x", "y", or "both".
+#' @param minor.grid.lines presence of minor grid lines, can be set to "x", "y", or "both".
 #' @param map whether the theme should be optimized for maps, can be set to TRUE or FALSE.
 #' @keywords theme_stat
 #' @export
@@ -26,7 +27,8 @@
 #' }}
 
 theme_stat <- function(base_size = 11, axis.label.pos = "top", axis.lines = "x",
-                       ticks = "x", minor.grid.lines = FALSE, map = FALSE){
+                       ticks = "x", major.grid.lines = "y", minor.grid.lines = "none",
+                       map = FALSE){
 
   palette <- RColorBrewer::brewer.pal("Greys", n=9)
   color.grid = palette[5]
@@ -142,27 +144,68 @@ theme_stat <- function(base_size = 11, axis.label.pos = "top", axis.lines = "x",
 
   # GITTERNETZLINIEN
 
-  if(minor.grid.lines == TRUE) {
-    theme_var <- theme_var +
-      ggplot2::theme(
-        panel.grid.minor = ggplot2::element_line(colour = color.grid,  size = 0.1),
-        panel.grid.major = ggplot2::element_line(colour = color.grid,  size = 0.2),
-        panel.grid.major.x = ggplot2::element_blank(), panel.grid.minor.x = ggplot2::element_blank()
-      )
+  # keine Gitternetzlinien
+  theme_var <- theme_var +
+    theme(panel.grid.major.x = ggplot2::element_blank(),
+          panel.grid.minor.x = ggplot2::element_blank(),
+          panel.grid.major.y = ggplot2::element_blank(),
+          panel.grid.minor.y = ggplot2::element_blank())
 
-  } else {
-    theme_var <- theme_var +
-      ggplot2::theme(
-        panel.grid.minor = ggplot2::element_blank(),
-        panel.grid.major = ggplot2::element_line(colour = color.grid,  size = 0.2),
-        panel.grid.major.x = ggplot2::element_blank(), panel.grid.minor.x = ggplot2::element_blank()
+  # kleine Gitternetzlinien
+  if(minor.grid.lines != "none"){
 
-      )
+    if(minor.grid.lines == "x") {
+      theme_var <- theme_var +
+        ggplot2::theme(
+          panel.grid.minor.x = ggplot2::element_line(colour = color.grid,  size = 0.1)
+        )
+    }
+
+    if(minor.grid.lines == "y") {
+      theme_var <- theme_var +
+        ggplot2::theme(
+          panel.grid.minor.y = ggplot2::element_line(colour = color.grid,  size = 0.1)
+        )
+    }
+
+    if(minor.grid.lines == "both") {
+      theme_var <- theme_var +
+        ggplot2::theme(
+          panel.grid.minor.y = ggplot2::element_line(colour = color.grid,  size = 0.1),
+          panel.grid.minor.x = ggplot2::element_line(colour = color.grid,  size = 0.1)
+        )
+    }
   }
 
-    # PANELS
-    theme_var <- theme_var +
-      ggplot2::theme(
+  # grosse Gitternetzlinien
+  if(major.grid.lines != "none"){
+
+    if(major.grid.lines == "x") {
+      theme_var <- theme_var +
+        ggplot2::theme(
+          panel.grid.major.x = ggplot2::element_line(colour = color.grid,  size = 0.2)
+        )
+    }
+
+    if(major.grid.lines == "y") {
+      theme_var <- theme_var +
+        ggplot2::theme(
+          panel.grid.major.y = ggplot2::element_line(colour = color.grid,  size = 0.2)
+        )
+    }
+
+    if(major.grid.lines == "both") {
+      theme_var <- theme_var +
+        ggplot2::theme(
+          panel.grid.major.y = ggplot2::element_line(colour = color.grid,  size = 0.2),
+          panel.grid.major.x = ggplot2::element_line(colour = color.grid,  size = 0.2)
+        )
+    }
+  }
+
+  # PANELS
+  theme_var <- theme_var +
+    ggplot2::theme(
       panel.spacing.x = unit(15, "pt"),
       panel.spacing.y = unit(15, "pt"),
       strip.background = ggplot2::element_blank()
@@ -182,22 +225,22 @@ theme_stat <- function(base_size = 11, axis.label.pos = "top", axis.lines = "x",
     # PLOT MARGINS
     ggplot2::theme(plot.margin = unit(c(0.3, 0.3, 0.3, 0.3), "cm"))
 
-    # MAP: no grid lines etc. for maps
-    if(isTRUE(map)){
-      theme_var <- theme_var +
-        theme(line = ggplot2::element_blank(),
-              axis.line.x = ggplot2::element_blank(),
-              axis.ticks.x = ggplot2::element_blank(),
-              axis.line.y = ggplot2::element_blank(),
-              axis.ticks.y = ggplot2::element_blank(),
-              axis.text = ggplot2::element_blank(),
-              axis.title = ggplot2::element_blank(),
-              panel.grid.major = ggplot2::element_blank(),
-              panel.grid.minor = ggplot2::element_blank()) +
-        theme(legend.position ='right',
-              legend.title = ggplot2::element_text(size = base_size),
-              legend.text = ggplot2::element_text(size = base_size))
-    }
-    theme_var
+  # MAP: no grid lines etc. for maps
+  if(isTRUE(map)){
+    theme_var <- theme_var +
+      theme(line = ggplot2::element_blank(),
+            axis.line.x = ggplot2::element_blank(),
+            axis.ticks.x = ggplot2::element_blank(),
+            axis.line.y = ggplot2::element_blank(),
+            axis.ticks.y = ggplot2::element_blank(),
+            axis.text = ggplot2::element_blank(),
+            axis.title = ggplot2::element_blank(),
+            panel.grid.major = ggplot2::element_blank(),
+            panel.grid.minor = ggplot2::element_blank()) +
+      theme(legend.position ='right',
+            legend.title = ggplot2::element_text(size = base_size),
+            legend.text = ggplot2::element_text(size = base_size))
+  }
+  theme_var
 }
 

--- a/R/theme_stat.r
+++ b/R/theme_stat.r
@@ -1,15 +1,15 @@
 #' theme_stat()
 #'
 #' This ggplot2 theme is based on ggplot2::theme_minimal(). It controls the non-data related characteristics of a plot (e.g., the font type).
-#' On top of that, the font size, the presence (or absence) of minor grid lines, axis lines, axis ticks and the axis label positions can be specified.
+#' On top of that, the font size, the major and minor grid lines, axis lines, axis ticks and the axis label positions can be specified.
 #'
 #' To use this theme in a R Markdown generated PDF document, insert `dev="cairo_pdf"` into `knitr::opts_chunk$set()`.
-#' @inheritParams ggplot2::theme_bw
+#' @inheritParams ggplot2::theme_minimal
 #' @param axis.label.pos position of x and y-axis labels, can be set to "top", "center", or "bottom".
-#' @param axis.lines presence of axis lines, can be set to "x", "y", or "both".
-#' @param ticks presence of axis ticks, can be set to "x", "y", or "both".
-#' @param major.grid.lines presence of major grid lines, can be set to "x", "y", or "both".
-#' @param minor.grid.lines presence of minor grid lines, can be set to "x", "y", or "both".
+#' @param axis.lines presence of axis lines, can be set to "x", "y", "both", or "none".
+#' @param ticks presence of axis ticks, can be set to "x", "y", "both", or "none".
+#' @param major.grid.lines presence of major grid lines, can be set to "x", "y", "both", or "none".
+#' @param minor.grid.lines presence of minor grid lines, can be set to "x", "y", "both", or "none".
 #' @param map whether the theme should be optimized for maps, can be set to TRUE or FALSE.
 #' @keywords theme_stat
 #' @export
@@ -79,68 +79,68 @@ theme_stat <- function(base_size = 11, axis.label.pos = "top", axis.lines = "x",
 
   ## Achsenlinien
 
-  if(axis.lines == "both") {
-    theme_var <- theme_var +
-      ggplot2::theme(
-        axis.line = ggplot2::element_line(colour = color.axis, size = 0.2),
-        axis.line.x = ggplot2::element_line(colour = color.axis, size = 0.25),
-        axis.line.y = ggplot2::element_line(colour = color.axis, size = 0.25)
-      )
-  }
+  if(axis.lines != "none"){
 
-  if (axis.lines == "x") {
-    theme_var <- theme_var +
-      ggplot2::theme(
-        axis.line = ggplot2::element_line(colour = color.axis, size = 0.2),
-        axis.line.x = ggplot2::element_line(colour = color.axis, size = 0.25),
-        axis.line.y = ggplot2::element_blank()
-      )
-  }
+    if(axis.lines == "both") {
+      theme_var <- theme_var +
+        ggplot2::theme(
+          axis.line = ggplot2::element_line(colour = color.axis, size = 0.2),
+          axis.line.x = ggplot2::element_line(colour = color.axis, size = 0.25),
+          axis.line.y = ggplot2::element_line(colour = color.axis, size = 0.25)
+        )
+    }
 
-  if (axis.lines == "y") {
-    theme_var <- theme_var +
-      ggplot2::theme(
-        axis.line = ggplot2::element_line(colour = color.axis, size = 0.2),
-        axis.line.y = ggplot2::element_line(colour = color.axis, size = 0.25),
-        axis.line.x = ggplot2::element_blank(),
-      )
+    if (axis.lines == "x") {
+      theme_var <- theme_var +
+        ggplot2::theme(
+          axis.line = ggplot2::element_line(colour = color.axis, size = 0.2),
+          axis.line.x = ggplot2::element_line(colour = color.axis, size = 0.25),
+          axis.line.y = ggplot2::element_blank()
+        )
+    }
+
+    if (axis.lines == "y") {
+      theme_var <- theme_var +
+        ggplot2::theme(
+          axis.line = ggplot2::element_line(colour = color.axis, size = 0.2),
+          axis.line.y = ggplot2::element_line(colour = color.axis, size = 0.25),
+          axis.line.x = ggplot2::element_blank(),
+        )
+    }
+
   }
 
   ## Achsenticks
 
-  if(ticks == "x") {
-    theme_var <- theme_var +
-      ggplot2::theme(
-        axis.ticks = ggplot2::element_line(colour = color.axis, size = 0.25),
-        axis.ticks.x = ggplot2::element_line(colour = color.axis, size = 0.25),
-        axis.ticks.y = ggplot2::element_blank(),
-        axis.ticks.length = unit(0.1, "cm")
-      )
+  if(ticks != "none"){
+    if(ticks == "x") {
+      theme_var <- theme_var +
+        ggplot2::theme(
+          #axis.ticks = ggplot2::element_line(colour = color.axis, size = 0.25),
+          axis.ticks.x = ggplot2::element_line(colour = color.axis, size = 0.25),
+          axis.ticks.length = unit(0.1, "cm")
+        )
+    }
 
+    if(ticks == "y") {
+      theme_var <- theme_var +
+        ggplot2::theme(
+          #axis.ticks = ggplot2::element_line(colour = color.axis, size = 0.25),
+          axis.ticks.y = ggplot2::element_line(colour = color.axis, size = 0.25),
+          axis.ticks.length = unit(0.1, "cm")
+        )
+    }
+
+    if(ticks == "both") {
+      theme_var <- theme_var +
+        ggplot2::theme(
+          #axis.ticks = ggplot2::element_line(colour = color.axis, size = 0.25),
+          axis.ticks.x = ggplot2::element_line(colour = color.axis, size = 0.25),
+          axis.ticks.y = ggplot2::element_line(colour = color.axis, size = 0.25),
+          axis.ticks.length = unit(0.1, "cm")
+        )
+    }
   }
-
-  if(ticks == "y") {
-    theme_var <- theme_var +
-      ggplot2::theme(
-        axis.ticks = ggplot2::element_line(colour = color.axis, size = 0.25),
-        axis.ticks.y = ggplot2::element_line(colour = color.axis, size = 0.25),
-        axis.ticks.x = ggplot2::element_blank(),
-        axis.ticks.length = unit(0.1, "cm")
-      )
-
-  }
-
-  if(ticks == "both") {
-    theme_var <- theme_var +
-      ggplot2::theme(
-        axis.ticks = ggplot2::element_line(colour = color.axis, size = 0.25),
-        axis.ticks.x = ggplot2::element_line(colour = color.axis, size = 0.25),
-        axis.ticks.y = ggplot2::element_line(colour = color.axis, size = 0.25),
-        axis.ticks.length = unit(0.1, "cm")
-      )
-
-  }
-
 
   # GITTERNETZLINIEN
 

--- a/man/theme_stat.Rd
+++ b/man/theme_stat.Rd
@@ -9,7 +9,8 @@ theme_stat(
   axis.label.pos = "top",
   axis.lines = "x",
   ticks = "x",
-  minor.grid.lines = FALSE,
+  major.grid.lines = "y",
+  minor.grid.lines = "none",
   map = FALSE
 )
 }
@@ -22,7 +23,9 @@ theme_stat(
 
 \item{ticks}{presence of axis ticks, can be set to "x", "y", or "both".}
 
-\item{minor.grid.lines}{presence of minor grid lines on the y-axis, can be set to TRUE or FALSE.}
+\item{major.grid.lines}{presence of major grid lines, can be set to "x", "y", or "both".}
+
+\item{minor.grid.lines}{presence of minor grid lines, can be set to "x", "y", or "both".}
 
 \item{map}{whether the theme should be optimized for maps, can be set to TRUE or FALSE.}
 }

--- a/man/theme_stat.Rd
+++ b/man/theme_stat.Rd
@@ -19,19 +19,19 @@ theme_stat(
 
 \item{axis.label.pos}{position of x and y-axis labels, can be set to "top", "center", or "bottom".}
 
-\item{axis.lines}{presence of axis lines, can be set to "x", "y", or "both".}
+\item{axis.lines}{presence of axis lines, can be set to "x", "y", "both", or "none".}
 
-\item{ticks}{presence of axis ticks, can be set to "x", "y", or "both".}
+\item{ticks}{presence of axis ticks, can be set to "x", "y", "both", or "none".}
 
-\item{major.grid.lines}{presence of major grid lines, can be set to "x", "y", or "both".}
+\item{major.grid.lines}{presence of major grid lines, can be set to "x", "y", "both", or "none".}
 
-\item{minor.grid.lines}{presence of minor grid lines, can be set to "x", "y", or "both".}
+\item{minor.grid.lines}{presence of minor grid lines, can be set to "x", "y", "both", or "none".}
 
 \item{map}{whether the theme should be optimized for maps, can be set to TRUE or FALSE.}
 }
 \description{
 This ggplot2 theme is based on ggplot2::theme_minimal(). It controls the non-data related characteristics of a plot (e.g., the font type).
-On top of that, the font size, the presence (or absence) of minor grid lines, axis lines, axis ticks and the axis label positions can be specified.
+On top of that, the font size, the major and minor grid lines, axis lines, axis ticks and the axis label positions can be specified.
 }
 \details{
 To use this theme in a R Markdown generated PDF document, insert `dev="cairo_pdf"` into `knitr::opts_chunk$set()`.

--- a/vignettes/Visualisierungen.Rmd
+++ b/vignettes/Visualisierungen.Rmd
@@ -21,11 +21,16 @@ library(statR)
 library(dplyr)
 library(ggplot2)
 library(tidyr)
+library(downloader)
+library(zip)
+library(sf)
+library(dichromat)
+library(ggrepel)
 ```
 
 Das **statR**-ggplot2-theme ist darauf ausgelegt, sich gut ins kantonale Corporate Design einzufügen. Es basiert auf dem ggplot2-theme 'minimal' und bestimmt diejenigen Grafikeigenschaften, die nichts mit den Daten an sich zu tun haben (z.B. die Schriftart).  
 
-Innerhalb des themes kann die Schriftgrösse, die Position der Achsenbeschriftungen sowie das Vorhandensein von Achsenlinien, Achsen-Ticks und kleineren Gitterlinien bestimmt werden.
+Innerhalb des themes kann die Schriftgrösse, die Position der Achsenbeschriftungen sowie das Vorhandensein von Achsenlinien, Achsen-Ticks und Gitterlinien bestimmt werden.
 
 ```{r}
 ggplot(mpg, aes(class,fill = drv))+
@@ -35,7 +40,8 @@ ggplot(mpg, aes(class,fill = drv))+
              axis.label.pos = "top",
              axis.lines = "x",
              ticks = "x",
-             minor.grid.lines = FALSE) +
+             minor.grid.lines = "y",
+             major.grid.lines = "y") +
   labs(title = "Title", subtitle = "Subtitle", caption = "Caption")
 ```
 
@@ -199,9 +205,7 @@ ggplot(mpg, aes(class,fill = drv))+
   geom_bar()+
   theme_stat()+
   scale_fill_manual(values=zhpal$zhblue)+
-  theme(legend.position="right", axis.text.x = element_text(angle=90,vjust = 0.5, hjust=0),
-        panel.grid.major = element_line(colour = "grey", size = 0.1),
-        panel.grid.minor = element_line(colour = "grey", size = 0.2))
+  theme(axis.text.x = element_text(angle=90,vjust = 0.5, hjust=0))
 
 
 # ggsave(file = "zhweb_plot.png", width=18, height=8, unit="cm")

--- a/vignettes/Visualisierungen.Rmd
+++ b/vignettes/Visualisierungen.Rmd
@@ -30,7 +30,7 @@ library(ggrepel)
 
 Das **statR**-ggplot2-theme ist darauf ausgelegt, sich gut ins kantonale Corporate Design einzufügen. Es basiert auf dem ggplot2-theme 'minimal' und bestimmt diejenigen Grafikeigenschaften, die nichts mit den Daten an sich zu tun haben (z.B. die Schriftart).  
 
-Innerhalb des themes kann die Schriftgrösse, die Position der Achsenbeschriftungen sowie das Vorhandensein von Achsenlinien, Achsen-Ticks und Gitterlinien bestimmt werden.
+Innerhalb des themes kann die Schriftgrösse, die Position der Achsenbeschriftungen sowie das Vorhandensein von Achsenlinien, Achsen-Ticks und Gitterlinien bestimmt werden (siehe `?theme_stat()`).
 
 ```{r}
 ggplot(mpg, aes(class,fill = drv))+
@@ -168,9 +168,7 @@ ggplot(mpg, aes(class,fill = drv,linetype=drv))+
   geom_bar(col ="black")+
   theme_stat()+
   scale_fill_manual(values=zhpal$zhblue)+
-  theme(legend.position="right", axis.text.x = element_text(angle=90,vjust = 0.5, hjust=0),
-        panel.grid.major = element_line(colour = "grey", size = 0.1),
-        panel.grid.minor = element_line(colour = "grey", size = 0.2))
+  theme(legend.position="right", axis.text.x = element_text(angle=90,vjust = 0.5, hjust=0))
 
 ```
 
@@ -204,8 +202,7 @@ Bei Grafiken, welche auf [zh.ch](zh.ch) Publiziert werden sollen, gilt es folgen
 ggplot(mpg, aes(class,fill = drv))+
   geom_bar()+
   theme_stat()+
-  scale_fill_manual(values=zhpal$zhblue)+
-  theme(axis.text.x = element_text(angle=90,vjust = 0.5, hjust=0))
+  scale_fill_manual(values=zhpal$zhblue)
 
 
 # ggsave(file = "zhweb_plot.png", width=18, height=8, unit="cm")


### PR DESCRIPTION
Ausbau der Argumente minor.grid.lines und major.grid.lines

- Optionen: "x", "y, "both", and "none"
- Flexible Handhabung der Gitterlinien, z.B. auch in Kombination mit (`coord_flip()`)

(resolves issues #35 and #28) 