### PR TITLE
adjust legend.location and plot.title.position

### DIFF
--- a/R/theme_stat.r
+++ b/R/theme_stat.r
@@ -256,11 +256,17 @@ theme_stat <- function(base_size = 11, axis.label.pos = "top", axis.lines = "x",
       legend.box.spacing = unit(0, "cm"),
       legend.box.margin = ggplot2::margin(0, 0, 1, -1, "mm"),
       legend.position = "top",
+      legend.location = "plot",
       legend.justification = "left",
       # legend.spacing = unit(c(0, 0, 0, 0), "mm"),
       legend.key.width = unit(4, "mm"),
       legend.key.height = unit(3, "mm")
     )+
+
+    # Titel
+    ggplot2::theme(
+      plot.title.position = "plot"
+    ) +
 
     # PLOT MARGINS
     ggplot2::theme(plot.margin = unit(c(0.3, 0.3, 0.3, 0.3), "cm"))


### PR DESCRIPTION
Titel- und Legendenposition gemäss Veränderung von Bild 1 zu Bild 2 angepasst (--> alles ganz linksbündig). Dies ist näher an der aktuellen Umsetzung von interaktiven Grafiken im zh-Web

Bild 1
<img width="856" height="595" alt="image" src="https://github.com/user-attachments/assets/8d5168ff-c7c9-4592-81d0-bdcda922f51f" />


Bild 2
<img width="855" height="596" alt="image" src="https://github.com/user-attachments/assets/a0dce84b-0ddd-48dd-91ac-0e3e72951e6f" />
